### PR TITLE
Add Docker support and helper scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+__pycache__/
+*.py[cod]
+*.so
+.venv/
+venv/
+env/
+build/
+dist/
+*.egg-info/
+
+in/
+out/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-key
+MODEL=small

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+RUN pip install .
+
+RUN mkdir /data /out
+ENV MODEL=small
+
+ENTRYPOINT ["sh", "-c", "auto_subtitle \"$1\" -o /out --model \"${MODEL}\"", "auto_subtitle"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Run the following to view all available options:
 
     auto_subtitle --help
 
+## Docker
+
+1. Copy `.env.example` to `.env` and add your OpenAI key.
+2. Build the image with `docker compose build`.
+3. Place input videos in `./in`; processed files will appear in `./out`.
+
+### Linux/macOS
+
+```bash
+./run.sh myvideo.mp4
+./run.sh myvideo.mp4 --model medium
+```
+
+### Windows
+
+```powershell
+.\run.ps1 myvideo.mp4
+.\run.ps1 myvideo.mp4 --model medium
+```
+
 ## License
 
 This script is open-source and licensed under the MIT License. For more details, check the [LICENSE](LICENSE) file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  autosub:
+    build: .
+    env_file: .env
+    volumes:
+      - ./in:/data:ro
+      - ./out:/out

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,32 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Video,
+    [string]$Model
+)
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "Docker is required but not installed."
+    exit 1
+}
+
+if (-not (Test-Path 'in')) { New-Item -ItemType Directory 'in' | Out-Null }
+if (-not (Test-Path 'out')) { New-Item -ItemType Directory 'out' | Out-Null }
+
+if (-not (Test-Path '.env')) {
+    Write-Error "Missing .env file. Copy .env.example to .env and set OPENAI_API_KEY."
+    exit 1
+}
+
+Get-Content .env | ForEach-Object {
+    if ($_ -and -not $_.StartsWith('#')) {
+        $parts = $_ -split '=', 2
+        [Environment]::SetEnvironmentVariable($parts[0], $parts[1])
+    }
+}
+
+$envArgs = @()
+if ($Model) {
+    $envArgs += '--env'
+    $envArgs += "MODEL=$Model"
+}
+
+docker compose run --rm @envArgs autosub "/data/$Video"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but not installed." >&2
+  exit 1
+fi
+
+if ! command -v docker compose >/dev/null 2>&1; then
+  echo "Docker Compose is required but not installed." >&2
+  exit 1
+fi
+
+mkdir -p in out
+
+if [ ! -f .env ]; then
+  echo "Missing .env file. Copy .env.example to .env and set OPENAI_API_KEY." >&2
+  exit 1
+fi
+
+set -a
+. ./.env
+set +a
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <video-file> [--model <model>]" >&2
+  exit 1
+fi
+
+VIDEO="$1"
+shift
+
+MODEL_ENV=""
+if [ "$1" = "--model" ] && [ -n "$2" ]; then
+  MODEL_ENV="-e MODEL=$2"
+fi
+
+if [ ! -f "in/$VIDEO" ]; then
+  echo "Input file in/$VIDEO not found." >&2
+  exit 1
+fi
+
+docker compose run --rm $MODEL_ENV autosub "/data/$VIDEO"


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose setup for containerized auto-subtitle
- provide run scripts for Linux/macOS and Windows
- document Docker usage and environment variables

## Testing
- `python -m compileall -q auto_subtitle`
- `bash -n run.sh`
- `pwsh -NoLogo -NoProfile -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7e89dd08324abe1c75578eb8296